### PR TITLE
Enhance the import order

### DIFF
--- a/rules/imports.js
+++ b/rules/imports.js
@@ -145,10 +145,22 @@ module.exports = {
 
     // ensure absolute imports are above relative imports and that unassigned imports are ignored
     // https://github.com/import-js/eslint-plugin-import/blob/master/docs/rules/order.md
-    // TODO: enforce a stricter convention in module import order?
-    'import/order': [
-      'error',
-      { groups: [['builtin', 'external', 'internal']] },
+     "import/order": [
+      "warn",
+      {
+        "alphabetize": {
+          "order": "asc"
+        },
+        "newlines-between": "always",
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index"
+        ]
+      }
     ],
 
     // Require a newline after the last import/require in a group


### PR DESCRIPTION
* add more groupings so similar directories are grouped
* enforce newlines between import groups for readability
* alphabetize imports
* warn about import order instead of erroring

This is fairly opinionated. I'd be happy to leave the grouping as is, instead of grouping parent and sibling imports.

This import rule is only good if you have an autoformatter that can do it for you (VSCode does it for me). Otherwise it's very painful.