### PR TITLE
Update TypeScript peerDependency to allow earlier versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "eslint": ">= 5.7.0",
     "jest": ">= 25.0.0",
-    "typescript": ">= 4.9.4"
+    "typescript": ">= 4.0.0"
   },
   "devDependencies": {
     "eslint": "^8.42.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,11 +2021,6 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@^5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
-  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
-
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"


### PR DESCRIPTION
The specified TypeScript version, 4.9.4, was released fairly recently. There's no need to lock TypeScript down to such a recent version, as it will cause errors when installing this config for folks using earlier versions of TypeScript.