### PR TITLE
Allow using void keyword with promises

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -453,5 +453,11 @@ module.exports = {
     // require or disallow Yoda conditions
     // https://eslint.org/docs/rules/yoda
     yoda: 'error',
+
+    // overrides
+
+    // allows circumventing no-floating-promises rule with eg.
+    // void someAsyncFunction()
+    'no-void': ['error', { allowAsStatement: true }],
   },
 };


### PR DESCRIPTION
We use the [no-floating-promises](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-floating-promises.md#ignore-void) rule with the `ignoreVoid` option. This allows us to use the void keyword to explicitly mark promises as intentionally not awaited and can be handy when we want to allow a promise to raise without handling at a certain layer of the application.

This conflicts with our `no-void` rule which disallows the void keyword entirely. Per [the documentation for the no-floating-promises ignoreVoid rule](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-floating-promises.md#ignorevoid):

> With this option set to true, and if you are using no-void, you should turn on the allowAsStatement option.

This commit turns on this option so we can now use promises with the "void" keyword.

Before:

```ts
someAsyncFn() // ✅ error no-floating-promises
void someAsyncFn() // ❌ error no-void
```

Now:

```ts
someAsyncFn() // ✅ error no-floating-promises
void someAsyncFn() // ✅ no error
```