### PR TITLE
Allow for...of loops

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -423,11 +423,6 @@ module.exports = {
           'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
       },
       {
-        selector: 'ForOfStatement',
-        message:
-          'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
-      },
-      {
         selector: 'LabeledStatement',
         message:
           'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',

--- a/rules/style.js
+++ b/rules/style.js
@@ -355,10 +355,6 @@ module.exports = {
     // https://eslint.org/docs/rules/no-bitwise
     'no-bitwise': 'error',
 
-    // disallow use of the continue statement
-    // https://eslint.org/docs/rules/no-continue
-    'no-continue': 'error',
-
     // disallow comments inline after code
     'no-inline-comments': 'off',
 


### PR DESCRIPTION
This rule originally comes from the Airbnb ruleset. These were restricted by Airbnb because browser support was lacking in 2018. Browser support for `for...of` is now at 97%. Additionally, not all of our users are writing for the browser. Finally, for...of loops are the simplest way to loop through arrays asynchronously in sequence:

```js
// this works, but .forEach and for...in do not
for await (const item of items) {
  await doSomething(item);
}
```

Similarly, this PR allows the use of `continue` statements. We often encourage early returns in methods, and to me `continue` is a similar concept, but in the context of a loop. I don't see a need to be opinionated about its usage.

https://caniuse.com/?search=for...of