### PR TITLE
Cut 2.1.0-alpha.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,9 @@ Nothing at the moment.
 
 - Add support for ESLint 9
 - Closes https://github.com/thoughtbot/eslint-config/issues/10
+
+## 2.1.0-alpha.1 - 2026-03-31
+
+- Convert configs to ESLint 9 flat configs
+- Add `"type": "module"` to package.json for ESM support
+- Remove `eslint-plugin-react-native-a11y` temporarily until it supports ESLint 9+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thoughtbot/eslint-config",
-  "version": "2.0.0",
+  "version": "2.1.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thoughtbot/eslint-config",
-      "version": "2.0.0",
+      "version": "2.1.0-alpha.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtbot/eslint-config",
-  "version": "2.0.0",
+  "version": "2.1.0-alpha.1",
   "author": "thoughtbot, Inc.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
This PR prepares the 2.1.0-alpha.1 alpha release of @thoughtbot/eslint-config, which includes the flat config migration from #21

Changes:
- Bump version to 2.1.0-alpha.1
- Update CHANGELOG